### PR TITLE
Added an option to enable or disable Ace Editor autocomplete.

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,18 +42,13 @@
                   Store data between sessions
                 </label>
               </li>
-              <li id="settingsmenu">Settings...</li>
-            </ul>
-          </li>
-          <li>
-            View
-            <ul>
               <li>
                 <label>
                   <input type="checkbox" id="view_enable_autocomplete" />
                   Enable autocomplete
                 </label>
               </li>
+              <li id="settingsmenu">Settings...</li>
             </ul>
           </li>
           <li>

--- a/index.html
+++ b/index.html
@@ -46,6 +46,17 @@
             </ul>
           </li>
           <li>
+            View
+            <ul>
+              <li>
+                <label>
+                  <input type="checkbox" id="view_enable_autocomplete" />
+                  Enable autocomplete
+                </label>
+              </li>
+            </ul>
+          </li>
+          <li>
             About
             <ul>
               <li id="infomenu">Info...</li>

--- a/js/text-editor.js
+++ b/js/text-editor.js
@@ -61,7 +61,7 @@ export function register(div_id, compileCode) {
     event.stop();
   });
 
-  // Bind View menu: "Enable autocomplete" checkbox (default: off)
+  // Bind Options menu: "Enable autocomplete" checkbox (default: off)
   (function () {
     var cb = document.getElementById('view_enable_autocomplete');
     if (cb) {

--- a/js/text-editor.js
+++ b/js/text-editor.js
@@ -42,8 +42,6 @@ export function register(div_id, compileCode) {
     enableSnippets: true,
   });
 
-  // e.completers = [sm83Completer];
-
   // Live autocomplete (auto-popup) disabled by default; toggle via View menu checkbox
   // Basic completion (Ctrl+Space) is always available
   e.setOption('enableLiveAutocompletion', false);

--- a/js/text-editor.js
+++ b/js/text-editor.js
@@ -38,7 +38,6 @@ export function register(div_id, compileCode) {
     tabSize: 2,
     useSoftTabs: true,
     navigateWithinSoftTabs: true,
-    // enableLiveAutocompletion: true,
     enableBasicAutocompletion: true,
     enableSnippets: true,
   });

--- a/js/text-editor.js
+++ b/js/text-editor.js
@@ -38,10 +38,16 @@ export function register(div_id, compileCode) {
     tabSize: 2,
     useSoftTabs: true,
     navigateWithinSoftTabs: true,
-    enableLiveAutocompletion: true,
+    // enableLiveAutocompletion: true,
+    enableBasicAutocompletion: true,
     enableSnippets: true,
   });
-  e.completers = [sm83Completer];
+
+  // e.completers = [sm83Completer];
+
+  // Live autocomplete (auto-popup) disabled by default; toggle via View menu checkbox
+  // Basic completion (Ctrl+Space) is always available
+  e.setOption('enableLiveAutocompletion', false);
 
   e.session.on('change', function (delta) {
     if (e.curOp && e.curOp.command.name) {
@@ -57,6 +63,19 @@ export function register(div_id, compileCode) {
     toggleBreakpoint(current_file, row + 1);
     event.stop();
   });
+
+  // Bind View menu: "Enable autocomplete" checkbox (default: off)
+  (function () {
+    var cb = document.getElementById('view_enable_autocomplete');
+    if (cb) {
+      cb.checked = localStorage.getItem('enableAutocomplete') === 'true';
+      e.setOption('enableLiveAutocompletion', cb.checked);
+      cb.addEventListener('change', function () {
+        localStorage.setItem('enableAutocomplete', cb.checked);
+        e.setOption('enableLiveAutocompletion', cb.checked);
+      });
+    }
+  })();
 
   editors.push(e);
 }


### PR DESCRIPTION
Add an "Enable autocomplete" checkbox in View menu to toggle live auto-completion.
It is implement by Ace editor itself. 
The previous unfinished implementation in sm83-complete.js has been preserved.
