### PR TITLE
update rgbds 1.0.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.13)
 
 project(rgbds_live)
 
-find_package(Git REQUIRED)
+find_program(_GIT_EXECUTABLE NAMES git)
 
 # it will apply patches/xxx.patch to xxx project (submodule)
 function(apply_git_patch PROJECT_NAME)
@@ -10,7 +10,7 @@ function(apply_git_patch PROJECT_NAME)
     set(PATCH_FILE "${CMAKE_CURRENT_SOURCE_DIR}/patches/${PROJECT_NAME}.patch")
 
     execute_process(
-        COMMAND ${GIT_EXECUTABLE} apply 
+        COMMAND ${_GIT_EXECUTABLE} apply 
             --ignore-space-change 
             --ignore-whitespace 
             --whitespace=nowarn    
@@ -23,7 +23,7 @@ function(apply_git_patch PROJECT_NAME)
 
     if(PATCH_NEEDED EQUAL 0)
         execute_process(
-            COMMAND ${GIT_EXECUTABLE} apply 
+            COMMAND ${_GIT_EXECUTABLE} apply 
                 --ignore-space-change 
                 --ignore-whitespace 
                 --whitespace=nowarn
@@ -79,7 +79,7 @@ set(RGBDS_LIVE_OUT_DIR "${CMAKE_BINARY_DIR}/out")
 
 # get rgbds version for build
 execute_process(
-    COMMAND ${GIT_EXECUTABLE} describe --tags --always
+    COMMAND ${_GIT_EXECUTABLE} describe --tags --always
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/rgbds"
     OUTPUT_VARIABLE RGBDS_VERSION_FROM_GIT
     OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -90,15 +90,9 @@ execute_process(
 set(RGBDS_TARGETS rgbasm rgblink rgbfix)
 
 # no git for you rgbds
-# this hack will stop rgbds build from obtain rgbds-live version from git
+# this will stop rgbds to find git package
 # it will be passed via BUILD_VERSION_STRING
-macro(execute_process)
-    if("${ARGV}" MATCHES "describe")
-        set(result 1)
-    else()
-        _execute_process(${ARGV})
-    endif()
-endmacro()
+set(CMAKE_DISABLE_FIND_PACKAGE_Git ON)
 
 # and we will put em into this target
 add_custom_target(rgbds)
@@ -106,10 +100,8 @@ add_custom_target(rgbds)
 # importing rgbds
 add_subdirectory(rgbds EXCLUDE_FROM_ALL)
 
-# restore execute_process
-macro(execute_process)
-    _execute_process(${ARGV})
-endmacro()
+# restore finding git package
+unset(CMAKE_DISABLE_FIND_PACKAGE_Git)
 
 # target specific configuration for rgbds
 foreach(TGT ${RGBDS_TARGETS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.13)
 
 project(rgbds_live)
 
+# we need to use find_program() instead find_package()
+# in other case set(CMAKE_DISABLE_FIND_PACKAGE_Git ON) for rgbds
+# will not work (Git_FOUND will be set already)
 find_program(_GIT_EXECUTABLE NAMES git)
 
 # it will apply patches/xxx.patch to xxx project (submodule)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,7 @@ cmake_minimum_required(VERSION 3.13)
 
 project(rgbds_live)
 
-# we need to use find_program() instead find_package()
-# in other case set(CMAKE_DISABLE_FIND_PACKAGE_Git ON) for rgbds
-# will not work (Git_FOUND will be set already)
-find_program(_GIT_EXECUTABLE NAMES git)
+find_package(Git REQUIRED)
 
 # it will apply patches/xxx.patch to xxx project (submodule)
 function(apply_git_patch PROJECT_NAME)
@@ -13,7 +10,7 @@ function(apply_git_patch PROJECT_NAME)
     set(PATCH_FILE "${CMAKE_CURRENT_SOURCE_DIR}/patches/${PROJECT_NAME}.patch")
 
     execute_process(
-        COMMAND ${_GIT_EXECUTABLE} apply 
+        COMMAND ${GIT_EXECUTABLE} apply 
             --ignore-space-change 
             --ignore-whitespace 
             --whitespace=nowarn    
@@ -26,7 +23,7 @@ function(apply_git_patch PROJECT_NAME)
 
     if(PATCH_NEEDED EQUAL 0)
         execute_process(
-            COMMAND ${_GIT_EXECUTABLE} apply 
+            COMMAND ${GIT_EXECUTABLE} apply 
                 --ignore-space-change 
                 --ignore-whitespace 
                 --whitespace=nowarn
@@ -82,7 +79,7 @@ set(RGBDS_LIVE_OUT_DIR "${CMAKE_BINARY_DIR}/out")
 
 # get rgbds version for build
 execute_process(
-    COMMAND ${_GIT_EXECUTABLE} describe --tags --always
+    COMMAND ${GIT_EXECUTABLE} describe --tags --always
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/rgbds"
     OUTPUT_VARIABLE RGBDS_VERSION_FROM_GIT
     OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -92,19 +89,17 @@ execute_process(
 # we need only those targets from rgbds
 set(RGBDS_TARGETS rgbasm rgblink rgbfix)
 
-# no git for you rgbds
-# this will stop rgbds to find git package
-# it will be passed via BUILD_VERSION_STRING
-set(CMAKE_DISABLE_FIND_PACKAGE_Git ON)
-
 # and we will put em into this target
 add_custom_target(rgbds)
 
 # importing rgbds
 add_subdirectory(rgbds EXCLUDE_FROM_ALL)
 
-# restore finding git package
-unset(CMAKE_DISABLE_FIND_PACKAGE_Git)
+# setting version in common target sets it globaly
+if(TARGET common)
+    target_compile_definitions(common PRIVATE "BUILD_VERSION_STRING=\"${RGBDS_VERSION_FROM_GIT}\"")
+    target_compile_options(common PRIVATE -Wno-macro-redefined)
+endif()
 
 # target specific configuration for rgbds
 foreach(TGT ${RGBDS_TARGETS})
@@ -117,7 +112,6 @@ foreach(TGT ${RGBDS_TARGETS})
         elseif("${TGT}" STREQUAL "rgbfix")
             set(EXP_NAME "createRgbFix")
         endif()
-        target_compile_definitions(${TGT} PRIVATE BUILD_VERSION_STRING="${RGBDS_VERSION_FROM_GIT}")
         target_link_options(${TGT} PRIVATE 
             "-sEXPORT_NAME=${EXP_NAME}"
             "-sEXPORTED_RUNTIME_METHODS=['FS']"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,15 @@ set(ZLIB_LIBRARY "z" CACHE STRING "" FORCE)
 set(PNG_FOUND TRUE CACHE BOOL "" FORCE)
 set(PNG_PNG_INCLUDE_DIR "${EMSCRIPTEN_SYSROOT}/include" CACHE PATH "" FORCE)
 set(PNG_LIBRARY "png" CACHE STRING "" FORCE)
+# ZLIB and LIBPNG are parts of emsdk .. just define libraries
+# expected by rgbds build system
+add_library(ZLIB::ZLIB INTERFACE IMPORTED GLOBAL)
+target_compile_options(ZLIB::ZLIB INTERFACE "-sUSE_ZLIB=1")
+target_link_options(ZLIB::ZLIB INTERFACE "-sUSE_ZLIB=1")
+
+add_library(PNG::PNG INTERFACE IMPORTED GLOBAL)
+target_compile_options(PNG::PNG INTERFACE "-sUSE_LIBPNG=1")
+target_link_options(PNG::PNG INTERFACE "-sUSE_LIBPNG=1")
 
 # silencing PkgConfig this project doesn't need this
 set(CMAKE_DISABLE_FIND_PACKAGE_PkgConfig ON CACHE BOOL "" FORCE)
@@ -79,11 +88,28 @@ execute_process(
 
 # we need only those targets from rgbds
 set(RGBDS_TARGETS rgbasm rgblink rgbfix)
+
+# no git for you rgbds
+# this hack will stop rgbds build from obtain rgbds-live version from git
+# it will be passed via BUILD_VERSION_STRING
+macro(execute_process)
+    if("${ARGV}" MATCHES "describe")
+        set(result 1)
+    else()
+        _execute_process(${ARGV})
+    endif()
+endmacro()
+
 # and we will put em into this target
 add_custom_target(rgbds)
 
 # importing rgbds
 add_subdirectory(rgbds EXCLUDE_FROM_ALL)
+
+# restore execute_process
+macro(execute_process)
+    _execute_process(${ARGV})
+endmacro()
 
 # target specific configuration for rgbds
 foreach(TGT ${RGBDS_TARGETS})

--- a/patches/rgbds.patch
+++ b/patches/rgbds.patch
@@ -21,7 +21,7 @@ index 1f801952..d05a1edc 100644
  	| label directive
  ;
 diff --git a/src/asm/symbol.cpp b/src/asm/symbol.cpp
-index b21c9d62..6a634926 100644
+index b21c9d62..56f4a13e 100644
 --- a/src/asm/symbol.cpp
 +++ b/src/asm/symbol.cpp
 @@ -801,3 +801,33 @@ void sym_Init(time_t now) {
@@ -49,7 +49,7 @@ index b21c9d62..6a634926 100644
 +	std::string name = valueBuf;
 +	name += fstk->name();
 +
-+	Symbol *sym = &createSymbol(name);
++	Symbol *sym = &createSymbol(intern(name));
 +	sym->type = SYM_LABEL;
 +	sym->data = static_cast<int32_t>(sect_GetSymbolOffset());
 +	sym->isExported = true;


### PR DESCRIPTION
apply fixes for build:
- createSymbol(intern(name))
- ZLIB::ZLIB and PNG::PNG
- temporarily override execute_process for passing rgbds version correctly